### PR TITLE
Fixed is_test_run Default

### DIFF
--- a/models/staging/stg_green_tripdata.sql
+++ b/models/staging/stg_green_tripdata.sql
@@ -35,6 +35,6 @@ SELECT
 FROM {{ source('staging', 'green_tripdata_partitioned') }}
 WHERE vendorid IS NOT NULL
 
-{% if var('is_test_run', default=true) %}
+{% if var('is_test_run', default=false) %}
     LIMIT 100
 {% endif %}

--- a/models/staging/stg_yellow_tripdata.sql
+++ b/models/staging/stg_yellow_tripdata.sql
@@ -40,6 +40,6 @@ SELECT
 
 FROM tripdata
 WHERE rn = 1
-{% if var('is_test_run', default=true) %}
+{% if var('is_test_run', default=false) %}
     LIMIT 100
 {% endif %}


### PR DESCRIPTION
Changed the default value for is_test_run within staging SQL queries from 'true' to 'false' so that data is not limited to 100 records for each data table