### PR TITLE
Fixed FHV Not Null Test

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -204,7 +204,7 @@ models:
             tests:
                 - unique:
                     severity: warn
-                - not null:
+                - not_null:
                     severity: warn
           - name: dispatching_base_num
             description: The TLC Base License Number of the base that dispatched the trip


### PR DESCRIPTION
Replaced 'not null' with 'not_null' for defining not null test on tri…pid in stg_fhv_tripdata