### PR TITLE
Fixed Accepted Values Test for FHV staging

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -233,6 +233,6 @@ models:
               For non-shared rides, this field is null.
             tests:
                 - accepted_values:
-                    values: [1, NULL]
+                    values: [1]
                     quote: false
 


### PR DESCRIPTION
Removed NULL from list of accepted values test for the field shared_ride_flag in the stg_fhv_tripdata model